### PR TITLE
Feature: mouse tracking

### DIFF
--- a/magpie.css
+++ b/magpie.css
@@ -140,7 +140,7 @@ body {
   transform: rotate(-45deg);
 }
 
-/* 
+/*
     PROGRESS BAR
 */
 .progress-bar-container {
@@ -203,7 +203,7 @@ input[name=answer] {
     text-transform: uppercase;
 }
 
-/* 
+/*
     likert scale rating task
     ---
     rating buttons
@@ -290,7 +290,7 @@ input[name=answer] {
     ---
     slider styles
 
-    slider  ---o--- 
+    slider  ---o---
     --- track
     o  thumb
  */
@@ -426,9 +426,22 @@ input[name=answer] {
     visibility: hidden;
 }
 
-/* 
+/*
+    LISTEN AND DECIDE
+ */
+.magpie-response-picture {
+    width: 25%;
+}
+.magpie-response-picture-left {
+    float: left;
+}
+.magpie-response-picture-right {
+    float: right;
+}
+
+/*
     POST TEST
-    
+
     age
     education
     languages
@@ -467,7 +480,7 @@ input[name=answer] {
     margin: 5px 0 0 0;
 }
 
-/* 
+/*
     THANKS VIEW
 
     submission loader

--- a/src/magpie-mousetracking.js
+++ b/src/magpie-mousetracking.js
@@ -1,24 +1,27 @@
 const magpieMousetracking = function (config, data) {
-    data.mousetrackingPath = []
-    data.mousetrackingStartTime = Date.now()
-    config.internal = {}
-    $view = $('.magpie-view')
-
-    if (!config.enabled) {
-        return
-    }
-
+    var $view = $('.magpie-view')
     var listener = function (evt) {
         var delta = Date.now() - data.mousetrackingStartTime
         data.mousetrackingPath.push({x: evt.originalEvent.layerX, y: evt.originalEvent.layerY, time: delta})
     }
 
-    $view.on('mouseover', listener)
+    if (!config.enabled) {
+        return
+    }
 
     // cleanup function
     data.mousetracking = {
         cleanup: function () {
             $view.off('mouseover', listener)
+        },
+        start: function() {
+            $view.on('mouseover', listener)
+            data.mousetrackingPath = []
+            data.mousetrackingStartTime = Date.now()
         }
+    }
+
+    if (config.autostart) {
+        data.mousetracking.start()
     }
 };

--- a/src/magpie-mousetracking.js
+++ b/src/magpie-mousetracking.js
@@ -1,8 +1,8 @@
 const magpieMousetracking = function (config, data) {
     var $view = $('.magpie-view')
     var listener = function (evt) {
-        data.mousetracking.x = evt.originalEvent.layerX
-        data.mousetracking.y = evt.originalEvent.layerY
+        data.mousetracking.x = evt.originalEvent.clientX
+        data.mousetracking.y = evt.originalEvent.clientY
     }
     var interval
 
@@ -17,16 +17,20 @@ const magpieMousetracking = function (config, data) {
         cleanup: function () {
             $view.off('mouseover', listener)
             clearInterval(interval)
+            data.mousetrackingDuration = data.mousetrackingTime[data.mousetrackingTime.length - 1]
         },
-        start: function() {
+        start: function (origin) {
+            if (!origin || !origin.x || !origin.y) {
+                origin = $view.getBoundingClientRect()
+            }
             $view.on('mouseover', listener)
             data.mousetrackingX = []
             data.mousetrackingY = []
             data.mousetrackingTime = []
             data.mousetrackingStartTime = Date.now()
-            interval = setInterval(function() {
-                data.mousetrackingX.push(data.mousetracking.x)
-                data.mousetrackingY.push(data.mousetracking.y)
+            interval = setInterval(function () {
+                data.mousetrackingX.push(data.mousetracking.x - origin.x)
+                data.mousetrackingY.push(data.mousetracking.y - origin.y)
                 data.mousetrackingTime.push(Date.now() - data.mousetrackingStartTime)
             }, 50)
         }

--- a/src/magpie-mousetracking.js
+++ b/src/magpie-mousetracking.js
@@ -1,9 +1,10 @@
 const magpieMousetracking = function (config, data) {
     var $view = $('.magpie-view')
     var listener = function (evt) {
-        var delta = Date.now() - data.mousetrackingStartTime
-        data.mousetrackingPath.push({x: evt.originalEvent.layerX, y: evt.originalEvent.layerY, time: delta})
+        data.mousetracking.x = evt.originalEvent.layerX
+        data.mousetracking.y = evt.originalEvent.layerY
     }
+    var interval
 
     if (!config.enabled) {
         return
@@ -11,13 +12,23 @@ const magpieMousetracking = function (config, data) {
 
     // cleanup function
     data.mousetracking = {
+        x: 0,
+        y: 0,
         cleanup: function () {
             $view.off('mouseover', listener)
+            clearInterval(interval)
         },
         start: function() {
             $view.on('mouseover', listener)
-            data.mousetrackingPath = []
+            data.mousetrackingX = []
+            data.mousetrackingY = []
+            data.mousetrackingTime = []
             data.mousetrackingStartTime = Date.now()
+            interval = setInterval(function() {
+                data.mousetrackingX.push(data.mousetracking.x)
+                data.mousetrackingY.push(data.mousetracking.y)
+                data.mousetrackingTime.push(Date.now() - data.mousetrackingStartTime)
+            }, 50)
         }
     }
 

--- a/src/magpie-mousetracking.js
+++ b/src/magpie-mousetracking.js
@@ -6,10 +6,6 @@ const magpieMousetracking = function (config, data) {
     }
     var interval
 
-    if (!config.enabled) {
-        return
-    }
-
     // cleanup function
     data.mousetracking = {
         x: 0,

--- a/src/magpie-mousetracking.js
+++ b/src/magpie-mousetracking.js
@@ -1,0 +1,24 @@
+const magpieMousetracking = function (config, data) {
+    data.mousetrackingPath = []
+    data.mousetrackingStartTime = Date.now()
+    config.internal = {}
+    $view = $('.magpie-view')
+
+    if (!config.enabled) {
+        return
+    }
+
+    var listener = function (evt) {
+        var delta = Date.now() - data.mousetrackingStartTime
+        data.mousetrackingPath.push({x: evt.originalEvent.layerX, y: evt.originalEvent.layerY, time: delta})
+    }
+
+    $view.on('mouseover', listener)
+
+    // cleanup function
+    data.mousetracking = {
+        cleanup: function () {
+            $view.off('mouseover', listener)
+        }
+    }
+};

--- a/src/magpie-utils.js
+++ b/src/magpie-utils.js
@@ -94,6 +94,11 @@ const magpieUtils = {
                 delete trial_data.canvas;
             }
 
+            if (config_info.mousetracking !== undefined) {
+                config_info.mousetracking.cleanup()
+                delete trial_data.mousetracking;
+            }
+
             return trial_data;
         },
         fill_defaults_post_test: function(config) {
@@ -182,6 +187,10 @@ const magpieUtils = {
 
                 if (data.canvas) {
                     magpieDrawShapes(data.canvas);
+                }
+
+                if (config.mousetracking) {
+                    magpieMousetracking(config.mousetracking, data)
                 }
 
                 resolve();

--- a/src/magpie-views.js
+++ b/src/magpie-views.js
@@ -59,7 +59,8 @@ const magpieViews = {
                         stim_duration: config.stim_duration,
                         data: config.data[CT],
                         evts: config.hook,
-                        view: view_type
+                        view: view_type,
+                        mousetracking: config.mousetracking
                     },
                     // After the first three steps of the trial view lifecycle (can all be empty)
                     // We call the following function and interactions are now enabled


### PR DESCRIPTION
I've had the chance to look at this already. This is a first attempt at implementing mouse tracking functionality, to be refined once more detailed experiment requirements are available.

It can be added to a view as follows:

```js
const main_block = magpieViews.view_generator("forced_choice", {
  // This will use all trials specified in `data`, you can user a smaller value (for testing), but not a larger value
  trials: main_trial_new.length,
  // name should be identical to the variable name
  name: 'main_trials',
  data: main_trial_new,
  mousetracking: {
    enabled: true,
    autostart: true
  }
  // you can add custom functions at different stages through a view's life cycle
  // hook: {
  //     after_response_enabled: check_response
  // }
});
```

And produces an additional field in the data output per trial that looks like this:

```js
{
  // ...
  mousetrackingPath: [
    {x: 12, y: 540, time: 12},
    {x: 130, y: 510, time: 230}
  ]
  // ...
}
```

 - `x` and `y` are pixel coordinates inside the view container (thus independent of screen dimensions)
 - `time` is the time in milliseconds since the start of mouse tracking (this is reset for each trial).

If `autostart` is set to true, tracking starts when the stimulus is presented. If it's set to false, the user may call `config.mousetracking.start()` in the view to start tracking the mouse until the end of the trial. This could be made available for hooks as well.

Note: Tracking mouse coordinates as implemented in this PR does not happen at regular intervals but only upon movement of the mouse.